### PR TITLE
delete control of outdated sequence when the event is updated

### DIFF
--- a/src/app/invitation-message/blue-bar/invitation-message-blue-bar.controller.js
+++ b/src/app/invitation-message/blue-bar/invitation-message-blue-bar.controller.js
@@ -54,7 +54,6 @@ function calInboxInvitationMessageBlueBarController(
       .then(getEventByUID)
       .then(selectEvent, handleNonExistentEvent)
       .then(assertEventInvolvesCurrentUser)
-      .then(assertInvitationSequenceIsNotOutdated)
       .then(bindEventToController)
       .then(bindReplyAttendeeToController)
       .then(bindCanSuggestChanges)
@@ -155,6 +154,7 @@ function calInboxInvitationMessageBlueBarController(
     return $q.reject(new InvalidMeetingError('Event does not involve current user.'));
   }
 
+  // This function throw an error when the event is updated 
   function assertInvitationSequenceIsNotOutdated(event) {
     if (+self.meeting.sequence < +event.sequence) {
       return $q.reject(new InvalidMeetingError('Sequence is outdated (event.sequence = ' + event.sequence + ').'));


### PR DESCRIPTION
**Demo :** 

![demosequenceOutdated](https://user-images.githubusercontent.com/43316837/119065377-4fa02500-b9d5-11eb-828f-7639a2e4c9b2.gif)

**Note:**

3.2.5.  DTSTAMP and SEQUENCE Properties

 
   The server MUST ensure that for each type of scheduling operation,
   the "SEQUENCE" iCalendar property value is updated as per iTIP
   [RFC5546].

**According to the RFC , the sequence is updated when event is too so what i suggest for this bug is to add information in event blue bar to inform user that the event is updated**